### PR TITLE
[AIR-5296] fetch airops app when subscribing to pusher to decide the channel prefix based on the app.public attribute

### DIFF
--- a/src/Pusher.ts
+++ b/src/Pusher.ts
@@ -21,17 +21,12 @@ class PusherClient {
 
   /**
    * Pusher constructor
-   * @param userId
-   * @param workspaceId
-   * @param hashedUserId
+   * @param isPublic
    * @param host
+   * @param headers
    */
-  constructor(userId?: string, workspaceId?: number, hashedUserId?: string, host?: string) {
-    if (!userId || !workspaceId || !hashedUserId) {
-      this.channelPrefix = 'public';
-    } else {
-      this.channelPrefix = 'private';
-    }
+  constructor(isPublic: boolean, host: string, headers?: Record<string, any>) {
+    this.channelPrefix = isPublic ? 'public' : 'private';
 
     this.pusher = new Pusher(APP_KEY, {
       cluster: APP_CLUSTER,
@@ -39,9 +34,7 @@ class PusherClient {
         transport: 'ajax',
         endpoint: `${host}/sdk_api/pusher/auth`,
         headers: {
-          ...(userId && { user_id: userId }),
-          ...(workspaceId && { workspace_id: workspaceId }),
-          ...(hashedUserId && { user_id_hashed: hashedUserId }),
+          ...(headers ?? {}),
           'content-type': 'application/json',
         },
       },

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -1,29 +1,35 @@
 import Apps from '../AirOpsApps';
 
 export type PusherCallback = (data: { content: string }) => void;
+
 export enum ChatAction {
   'AgentResponse' = 'agent-response',
   'AgentAction' = 'agent-action',
   'AgentActionError' = 'agent-action-error',
   'Completed' = 'completed',
 }
+
 export type AgentResponseData = {
   action: ChatAction.AgentResponse;
   token: string;
   stream_finished: boolean;
   result: string;
 };
+
 export type AgentActionData = {
   action: ChatAction.AgentAction;
   tool: string;
   tool_input: Record<string, string>;
 };
+
 export type AgentActionErrorData = {
   action: ChatAction.AgentActionError;
   tool: string;
   tool_error: string;
 };
+
 export type CompletedData = { action: ChatAction.Completed; result: string };
+
 export type PusherChatCallback = (
   arg: AgentResponseData | AgentActionData | AgentActionErrorData | CompletedData
 ) => void;


### PR DESCRIPTION
[air-5296](https://linear.app/airops/issue/AIR-5296/[sdk]-decide-to-which-channel-to-subscribe-depending-on-the-app)

- Decide which channelPrefix to use on pusher depending on the app no ton how the SDK was initialized